### PR TITLE
[Feature] Add hooks for insert, update and remove events

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Hooks are callbacks that can be triggered when a mapping performs the successful
 A hook registered against a mapper will be used for all top level mappings it creates.
 
 ```php
-$mapper->registerHook('update', function ($table, $key, $updated, $original) {
+$mapper->registerHook('updated', function ($table, $key, $updated, $original) {
     printf('Table %s (ID: %s) was updated...', $table, implode(':', $key));
 });
 ```

--- a/README.md
+++ b/README.md
@@ -118,5 +118,16 @@ $saved = $mapper->eq('id', 'abc123')->findOne();
 // $saved will be identical in structure to post
 ```
 
+#### Hooks
+
+Hooks are callbacks that can be triggered when a mapping performs the successful insert, update or removal of a record.
+A hook registered against a mapper will be used for all top level mappings it creates.
+
+```php
+$mapper->registerHook('update', function ($table, $key, $updated, $original) {
+    printf('Table %s (ID: %s) was updated...', $table, implode(':', $key));
+});
+```
+
 #### Known Issues
 * One-to-one mappings where the relationship is associated via primary key do not work as intended

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -13,6 +13,11 @@ class Mapper
     private $db;
 
     /**
+     * @var array
+     */
+    private $hooks = [];
+
+    /**
      * Mapper constructor.
      *
      * @param Database $db
@@ -30,7 +35,7 @@ class Mapper
      */
     public function mapping(Definition $definition)
     {
-        return new Mapping($this->db, $definition);
+        return new Mapping($this->db, $definition, [], $this->hooks);
     }
 
     /**
@@ -72,5 +77,16 @@ class Mapper
     public function getLogMessages()
     {
         return $this->db->getLogMessages();
+    }
+
+    /**
+     * Registers a new hook.
+     *
+     * @param string   $event
+     * @param callable $hook
+     */
+    public function hook(string $event, callable $hook)
+    {
+        $this->hooks[$event][] = $hook;
     }
 }

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -85,7 +85,7 @@ class Mapper
      * @param string   $event
      * @param callable $hook
      */
-    public function hook(string $event, callable $hook)
+    public function registerHook(string $event, callable $hook)
     {
         $this->hooks[$event][] = $hook;
     }


### PR DESCRIPTION
This PR adds support for hooks (callbacks) that are triggered whenever a mapping performs the insert, update or removal of a record. Hooks are registered against mappers and triggered by all top-level mappings that they create.

```php
$mapper->registerHook('updated', function ($table, $key, $updated, $original) {
    printf(
        'Table %s (ID: %s) was updated from %s to %s',
        $table,
        implode(':', $key),
        $original,
        $updated
    );

    // "Table posts (ID: 11) was updated from Array(...) to Array(...)"
});
```