### PR TITLE
[Enhancement] - Transactions

### DIFF
--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -111,10 +111,6 @@ class Mapping extends Table
         }
 
         if (!parent::insert($base)) {
-            if ($useTransaction) {
-                $this->db->cancelTransaction();
-            }
-
             return false;
         }
 
@@ -148,10 +144,6 @@ class Mapping extends Table
                 $item[$property->getForeignColumn()] = $data[$property->getLocalColumn()];
 
                 if (!$mapping->insert($item)) {
-                    if ($useTransaction) {
-                        $this->db->cancelTransaction();
-                    }
-
                     return false;
                 }
             }

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -111,6 +111,7 @@ class Mapping extends Table
         }
 
         if (!parent::insert($base)) {
+            // Transaction already cancelled by the statement handler
             return false;
         }
 
@@ -144,6 +145,7 @@ class Mapping extends Table
                 $item[$property->getForeignColumn()] = $data[$property->getLocalColumn()];
 
                 if (!$mapping->insert($item)) {
+                    // Transaction already cancelled by the statement handler
                     return false;
                 }
             }
@@ -169,7 +171,6 @@ class Mapping extends Table
         if ($this->definition->isReadOnly()) {
             return true;
         }
-
 
         foreach ($primaryKey as $column) {
             if (!array_key_exists($column, $data)) {

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -238,6 +238,53 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Bacon', $saved['orders'][0]['items'][2]['description']);
     }
 
+    public function testInsertRollback()
+    {
+        $customer = [
+            'id' => 3,
+            'name' => 'Dave Matthews',
+            'orders' => [
+                [
+                    'id' => 4,
+                    'date_created' => '2018-02-01',
+                    'discount' => [
+                        'description' => 'Dessert Discount',
+                        'amount' => 20
+                    ],
+                    'items' => [
+                        [
+                            'id' => 7,
+                            'description' => 'Ice Cream',
+                            'amount' => 400
+                        ],
+                        [
+                            'id' => 7,
+                            'description' => 'Cookies',
+                            'amount' => '230'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->getMapping()->insert($customer);
+        $inserted = $this->getMapping()->eq('id', 3)->findOne();
+
+        $this->assertNull($inserted);
+    }
+
+    public function testUpdateRollback()
+    {
+        $customer = $this->getMapping()->eq('id', 1)->findOne();
+        $original = $customer;
+
+        $customer['orders'][0]['items'][] = ['id' => '3'];
+        $this->getMapping()->update($customer);
+
+        $updated = $this->getMapping()->eq('id', 1)->findOne();
+        $this->assertEquals($original, $updated);
+    }
+
     /**
      * Returns a new mapping for testing.
      *


### PR DESCRIPTION
This PR automatically wraps transactions around mapper inserts, updates and deletions. When persisting a record, all or none of the changes should be committed.

If the database connection is already in a transaction, then handling will be skipped and left as a responsibility of the calling code.

PicoDb already cancels transactions when handling SQL exceptions, so manual rollback has been omitted in some scenarios. 