### PR TITLE
[HOTFIX] - Use correct SQL condition for null values

### DIFF
--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -177,7 +177,11 @@ class Mapping extends Table
                 return false;
             }
 
-            $this->eq($column, $data[$column]);
+            if (is_null($data[$column])) {
+                $this->isNull($column);
+            } else {
+                $this->eq($column, $data[$column]);
+            }
         }
 
         if (!$original = $this->findOne()) {


### PR DESCRIPTION
Updating a record based on a composite primary key with a null value currently fails (affects zero rows) as the mapper tries to use the SQL equality operator. This fix checks for null values and uses the `IS NULL` operator instead.