### PR TITLE
Add PHP 7.4 to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-6.5.14.phar


### PR DESCRIPTION
This PR adds PHP 7.4 support to TravisCI tests.