### PR TITLE
[HOTFIX] - Add handling for null primary keys during deletion

### DIFF
--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -429,7 +429,7 @@ class Mapping extends Table
                         });
                     }
 
-                    $query->in($primary, $primaryValues);
+                    $query->in($primary, array_values($primaryValues));
                     $query->closeOr();
 
                     $result = $deletion ? $query->update([$deletion => gmdate('Y-m-d H:i:s')]) : $query->remove();


### PR DESCRIPTION
This PR fixes a bug where records with composite primary keys featuring a null value cannot be deleted.

When building the grouped query, null values are checked using `IS NULL`. When building the `IN` clause for the final column, `column IS NULL OR column in ()` is used when a null value is present.