### PR TITLE
[HOTFIX] - Fix one-to-one relationship bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $post = [
     'author' => [
         'id' => 'zxy321',
         'name' => 'John Doe'
-    ]
+    ],
     'title' => 'Data Mappers Rock',
     'content' => 'They save you time',
     'comments' => [
@@ -112,6 +112,7 @@ $post = [
             ],
             'content' => 'Nice article!'
         ],
+    ]
 ];
 
 $mapper->save($post);

--- a/README.md
+++ b/README.md
@@ -131,6 +131,3 @@ $mapper->registerHook('updated', function ($table, $key, $updated, $original) {
     printf('Table %s (ID: %s) was updated...', $table, implode(':', $key));
 });
 ```
-
-#### Known Issues
-* One-to-one mappings where the relationship is associated via primary key do not work as intended

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -328,8 +328,8 @@ class Mapping extends Table
             $propertyOriginal = $original[$property->getName()] ?? [];
 
             if (!$property->isCollection()) {
-                $propertyData = [$propertyData];
-                $propertyOriginal = [$propertyOriginal];
+                $propertyData = $propertyData ? [$propertyData] : [];
+                $propertyOriginal = $propertyOriginal ? [$propertyOriginal] : [];
             }
 
             $mapping = new static($this->db, $property->getDefinition(), [$property->getForeignColumn()]);

--- a/tests/Fixtures.sql
+++ b/tests/Fixtures.sql
@@ -11,6 +11,9 @@ CREATE TABLE items (id INTEGER PRIMARY KEY, order_id INTEGER, description TEXT, 
 DROP TABLE IF EXISTS discounts;
 CREATE TABLE discounts (id INTEGER PRIMARY KEY, order_id INTEGER, description TEXT, amount INTEGER);
 
+DROP TABLE IF EXISTS orders_fulfillments;
+CREATE TABLE orders_fulfillments (order_id INTEGER, employee_id INTEGER);
+
 -- Seed database
 INSERT INTO customers (id, name) VALUES
 (1, 'John Doe'),

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -131,6 +131,7 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $customer = $this->getMapping()->eq('id', 1)->findOne();
         $original = $customer;
 
+        $customer['orders'][0]['fulfillment'] = ['employee_id' => 2];
         $customer['orders'][0]['items'][1]['description'] = 'Jumbo Eggs';
         $customer['orders'][0]['items'][] = ['id' => 7, 'description' => 'Cheese', 'amount' => 300];
 
@@ -296,13 +297,17 @@ class MappingTest extends \PHPUnit\Framework\TestCase
             ->withColumns('description', 'amount')
             ->useAutoIncrement();
 
+        $fulfillment = (new Definition('orders_fulfillments', ['order_id', 'employee_id']));
+
         $item = (new Definition('items'))
             ->withColumns('id', 'description', 'amount', 'modified')
             ->withModificationData(['modified' => '2019-01-02 03:04:05']);
 
+
         $order = (new Definition('orders'))
             ->withColumns('id', 'date_created')
             ->withOne($discount, 'discount', 'order_id')
+            ->withOne($fulfillment, 'fulfillment', 'order_id')
             ->withMany($item, 'items', 'order_id')
             ->withDeletionTimestamp('date_deleted');
 
@@ -343,4 +348,3 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         return new Mapping($this->db, $customer);
     }
 }
-


### PR DESCRIPTION
This PR fixes a bug that occurs when a one-to-one relationship is created for the first time. In order to find items that need inserting or deleting, `Mapping::replace()` performs a diff between original and new property data. Because an empty array was being used for missing non-collection properties, it was being returned in the diffs with subsequent code throwing notices when trying to access primary keys within.

The solution is to make `$propertyData` and `$propertyOriginal` empty arrays for non-collection items when a value isn't present, instead of an array with an empty array as the only item. This leads to correct diffs and prevents undesirable branches of code from running.