### PR TITLE
[ENHANCEMENT] - Check deletion timestamp when updating or deleting records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 .idea/
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="false"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true">
-    <testsuite name="default">
-        <directory suffix="Test.php">tests</directory>
-    </testsuite>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuite name="default">
+    <directory suffix="Test.php">tests</directory>
+  </testsuite>
 </phpunit>

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -304,6 +304,10 @@ class Mapping extends Table
             }
         }
 
+        if ($this->definition->getDeletionTimestamp()) {
+            $query->isNull($this->definition->getDeletionTimestamp());
+        }
+
         $base = $this->getBaseData($data);
         $originalBase = $this->getBaseData($original);
 
@@ -432,7 +436,7 @@ class Mapping extends Table
                     $query->in($primary, array_values($primaryValues));
                     $query->closeOr();
 
-                    $result = $deletion ? $query->update([$deletion => gmdate('Y-m-d H:i:s')]) : $query->remove();
+                    $result = $deletion ? $query->isNull($deletion)->update([$deletion => gmdate('Y-m-d H:i:s')]) : $query->remove();
                     if (!$result) {
                         throw new \Exception('Failed to delete records.');
                     }

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -303,7 +303,6 @@ class MappingTest extends \PHPUnit\Framework\TestCase
             ->withColumns('id', 'description', 'amount', 'modified')
             ->withModificationData(['modified' => '2019-01-02 03:04:05']);
 
-
         $order = (new Definition('orders'))
             ->withColumns('id', 'date_created')
             ->withOne($discount, 'discount', 'order_id')


### PR DESCRIPTION
This PR updates the `Mapping::replace()` and `Mapping:delete()` methods so that records with a deletion timestamp set are not updated or deleted. This fixes undesirable behaviour which can arise when uniqueness constraints have to be enforced at the application level rather than through the schema, e.g. when the mapping's primary key(s) are not sufficient in identifying a single record because multiple deleted records exist for a given key.