### PR TITLE
[HOTFIX] - Prevent SQL IN condition with empty values during deletion

### DIFF
--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -433,7 +433,10 @@ class Mapping extends Table
                         });
                     }
 
-                    $query->in($primary, array_values($primaryValues));
+                    if (!empty($primaryValues)) {
+                        $query->in($primary, array_values($primaryValues));
+                    }
+
                     $query->closeOr();
 
                     $result = $deletion ? $query->isNull($deletion)->update([$deletion => gmdate('Y-m-d H:i:s')]) : $query->remove();


### PR DESCRIPTION
This PR fixes a bug encountered when a `Mapping` attempts to delete records where the final key in a composite primary key is comprised entirely of `null` values. A SQL IN condition is attempted with an empty array of values, causing PicoDb to throw an exception instead of skipping the condition.

With version [2.0.0](https://github.com/tithely/picomapper/releases/tag/2.0.0), the dependency on `elvanto/picodb` was updated to version 4.0.0. This update introduced new logic in PicoDb's `Table::in()` function which results in an exception being thrown when an empty array of values is provided. Previously, an empty array of values would have been ignored and no condition would have been attached.

This fix works by first checking that there are non-null values to be checking for before adding them in an IN clause. This should only ever be the case where there are `null` values present, and so the `->isNull()` added prior to the `->in()` will be sufficient to ensure only the desired set of records is deleted.