### PR TITLE
Support JOIN directly on Mapping

### DIFF
--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -577,7 +577,7 @@ class Mapping extends Table
         $required = array_merge($this->definition->getColumns(), $this->columns);
 
         foreach ($this->definition->getProperties() as $item) {
-            $required[] = in_array($item->getLocalColumn(), $this->definition->getPrimaryKey()) ? $this->prefixTableNameTo($item->getLocalColumn()) : $item->getLocalColumn();
+            $required[] = $item->getLocalColumn();
         }
 
         foreach (array_unique($required) as $column) {

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -826,14 +826,15 @@ class Mapping extends Table
     }
 
     /**
-     * Checks if any table name is appended to the column
+     * Checks if string is a valid SQL column and has no table prefix.
      *
      * @param $column
      * @return bool
      */
-    function isPrefixed($column): bool
+    private function requiresPrefix($column): bool
     {
-        return strpos($column, '.') !== false;
+        $pattern = '/^[a-zA-Z_][a-zA-Z0-9_]*$/';
+        return (bool) preg_match($pattern, $column);
     }
 
     /**
@@ -844,7 +845,7 @@ class Mapping extends Table
      */
     function prefixTableNameTo($input, $table) {
         if (is_string($input)) {
-            return $this->isPrefixed($input) ? $input : "$table.$input";
+            return $this->requiresPrefix($input) ? "$table.$input" : $input;
         } elseif (is_array($input)) {
             $output = [];
             foreach ($input as $key => $value) {
@@ -867,7 +868,7 @@ class Mapping extends Table
      */
     function removeTablePrefixFrom($input, $table) {
         if (is_string($input)) {
-            return $this->isPrefixed($input) ? substr($input, strlen($table) + 1) : $input;
+            return $this->requiresPrefix($input) ? $input : substr($input, strlen($table) + 1);
         } elseif (is_array($input)) {
             $output = [];
             foreach ($input as $key => $value) {

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -448,7 +448,7 @@ class Mapping extends Table
         }
     }
 
-/**
+    /**
      * Returns an associative array mapping table names to primary keys
      * constructed by recursively scanning data.
      *
@@ -620,20 +620,33 @@ class Mapping extends Table
     }
 
     /**
-     * Checks if string is a valid SQL column and has no table prefix.
+     * Checks if string is a valid SQL column name and has no table prefix.
      *
-     * @param $column
+     * @param string $column
      * @return bool
      */
-    private function requiresPrefix($column): bool
+    private function requiresPrefix(string $column): bool
     {
         $pattern = '/^[a-zA-Z_][a-zA-Z0-9_]*$/';
         return (bool) preg_match($pattern, $column);
     }
 
     /**
-     * Appends table name to provided value. Works recursively with arrays. If a dictionary is passed, only modifies
-     * first level of dictionary keys, does not work recursively with dictionaries.
+     * Appends table name to provided value. Works with strings, arrays, and dictionaries. If multidimensional array is
+     * passed, the values will be updated recursively. If a dictionary is passed, only the
+     * first level of dictionary keys will be modified, does not work recursively with nested dictionaries. It is also
+     * protected from multiple passes and will only prefix the column name once.
+     *
+     * String Example:
+     *      'field' -> 'table.field'
+     * Array Example:
+     *      ['field', 'field2'] -> ['table.field', 'table.field2']
+     *      ['field', ['field2', 'field3']] -> ['table.field', ['table.field2', 'table.field3']]
+     * Dictionary Example:
+     *      ['field' => 'value'] -> ['table.field' => 'value']
+     *      ['field' => ['field2' => 'value']] -> ['table.field' => ['field2' => 'value']]
+     *      [['field' => 'value']] -> [['table.field' => 'value']]
+     *      [['field' => ['field2' => 'value']]] -> [['table.field' => ['field2' => 'value']]]
      *
      * @return string | array
      */
@@ -645,9 +658,9 @@ class Mapping extends Table
             $output = [];
             foreach ($input as $key => $value) {
                 if (is_string($key)) {
-                    $key = $this->prefixTableNameTo($key, $table);
+                    $key = $this->prefixTableNameTo($key);
                 } else {
-                    $value = $this->prefixTableNameTo($value, $table);
+                    $value = $this->prefixTableNameTo($value);
                 }
                 $output[$key] = $value;
             }

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -27,8 +27,6 @@ class Mapping extends Table
      */
     protected $lastId;
 
-    protected bool $hasJoin = false;
-
     /**
      * Mapping constructor.
      *
@@ -54,7 +52,7 @@ class Mapping extends Table
     public function findOne()
     {
         if ($this->getDeletionTimestamp()) {
-            $this->isNull($this->getDeletionTimestamp());
+            $this->isNull($this->getDeletionTimestamp(true));
         }
 
         $this->columns(...$this->buildColumns());
@@ -77,7 +75,7 @@ class Mapping extends Table
     public function findAll()
     {
         if ($this->getDeletionTimestamp()) {
-            $this->isNull($this->getDeletionTimestamp());
+            $this->isNull($this->getDeletionTimestamp(true));
         }
 
         $this->columns(...$this->buildColumns());
@@ -307,7 +305,7 @@ class Mapping extends Table
         }
 
         if ($this->getDeletionTimestamp()) {
-            $query->isNull($this->getDeletionTimestamp());
+            $query->isNull($this->getDeletionTimestamp(true));
         }
 
         $base = $this->getBaseData($data);
@@ -450,208 +448,12 @@ class Mapping extends Table
         }
     }
 
-    /**
-     * Override these table methods and set $isJoin to true
-     *
-     * @method  $this   join($table, $foreign_column, $local_column, $local_table, $alias)
-     * @method  $this   left($table1, $alias1, $column1, $table2, $column2)
-     * @method  $this   inner($table1, $alias1, $column1, $table2, $column2)
-     * @method  $this   joinSubquery($subQuery, $alias, $foreign_column, $local_column, $local_table)
-     * @method  $this   innerJoinSubquery($subQuery, $alias, $foreign_column, $local_column, $local_table)
-     *
-     */
-
-    public function join($table, $foreign_column, $local_column, $local_table = '', $alias = '')
-    {
-        $this->hasJoin = true;
-        return parent::join($table, $foreign_column, $local_column, $local_table, $alias);
+    private function getPrimaryKey($prefixed = false) {
+        return ($prefixed) ? $this->prefixTableNameTo($this->definition->getPrimaryKey(), $this->definition->getTable()) : $this->definition->getPrimaryKey();
     }
 
-    public function left($table1, $alias1, $column1, $table2, $column2)
-    {
-        $this->hasJoin = true;
-        return parent::left($table1, $alias1, $column1, $table2, $column2);
-    }
-
-    public function joinSubquery(Table $subQuery, string $alias, string $foreign_column, string $local_column, string $local_table = ''): Table
-    {
-        $this->hasJoin = true;
-        return parent::joinSubquery($subQuery, $alias, $foreign_column, $local_column, $local_table);
-    }
-
-    public function innerJoinSubquery(Table $subQuery, string $alias, string $foreign_column, string $local_column, string $local_table = ''): Table
-    {
-        $this->hasJoin = true;
-        return parent::innerJoinSubquery($subQuery, $alias, $foreign_column, $local_column, $local_table);
-    }
-
-    /**
-     * Override these table methods and prefix the mapping table to all columns which are ambiguous
-     *
-     * @method   $this   eq($column, $value)
-     * @method   $this   neq($column, $value)
-     * @method   $this   in($column, array $values)
-     * @method   $this   inSubquery($column, Table $subquery)
-     * @method   $this   notIn($column, array $values)
-     * @method   $this   notInSubquery($column, Table $subquery)
-     * @method   $this   like($column, $value)
-     * @method   $this   ilike($column, $value)
-     * @method   $this   notLike($column, $value)
-     * @method   $this   gt($column, $value)
-     * @method   $this   gtSubquery($column, Table $subquery)
-     * @method   $this   lt($column, $value)
-     * @method   $this   ltSubquery($column, Table $subquery)
-     * @method   $this   gte($column, $value)
-     * @method   $this   gteSubquery($column, Table $subquery)
-     * @method   $this   lte($column, $value)
-     * @method   $this   lteSubquery($column, Table $subquery)
-     * @method   $this   between($column, $lowValue, $highValue)
-     * @method   $this   notBetween($column, $lowValue, $highValue)
-     * @method   $this   isNull($column)
-     * @method   $this   notNull($column)
-     * @method  $this   orderBy($column)
-     * @method  $this   asc($column)
-     * @method  $this   desc($column)
-     * @method  $this   groupBy()
-     */
-
-    /**
-     * @inheritDoc
-     */
-    public function eq($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::eq($this->hasJoin ? $prefixedColumn : $column,$value);
-    }
-
-    public function neq($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::neq($this->hasJoin ? $prefixedColumn : $column,$value);
-    }
-
-    public function in($column, array $values) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::in($this->hasJoin ? $prefixedColumn : $column, $values);
-    }
-
-    public function inSubquery($column, Table $subquery) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::inSubquery($this->hasJoin ? $prefixedColumn : $column, $subquery);
-    }
-
-    public function notIn($column, array $values) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::notIn($this->hasJoin ? $prefixedColumn : $column, $values);
-    }
-
-    public function notInSubquery($column, Table $subquery) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::notInSubquery($this->hasJoin ? $prefixedColumn : $column, $subquery);
-    }
-
-    public function like($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::like($this->hasJoin ? $prefixedColumn : $column, $value);
-    }
-
-    public function ilike($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::ilike($this->hasJoin ? $prefixedColumn : $column, $value);
-    }
-
-    public function notLike($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::notLike($this->hasJoin ? $prefixedColumn : $column, $value);
-    }
-
-    public function gt($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::gt($this->hasJoin ? $prefixedColumn : $column, $value);
-    }
-
-    public function gtSubquery($column, Table $subquery) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::gtSubquery($this->hasJoin ? $prefixedColumn : $column, $subquery);
-    }
-
-    public function lt($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::lt($this->hasJoin ? $prefixedColumn : $column, $value);
-    }
-
-    public function ltSubquery($column, Table $subquery) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::ltSubquery($this->hasJoin ? $prefixedColumn : $column, $subquery);
-    }
-
-    public function gte($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::gte($this->hasJoin ? $prefixedColumn : $column, $value);
-    }
-
-    public function gteSubquery($column, Table $subquery) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::gteSubquery($this->hasJoin ? $prefixedColumn : $column, $subquery);
-    }
-
-    public function lte($column, $value) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::lte($this->hasJoin ? $prefixedColumn : $column, $value);
-    }
-
-    public function lteSubquery($column, Table $subquery) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::lteSubquery($this->hasJoin ? $prefixedColumn : $column, $subquery);
-    }
-
-    public function between($column, $lowValue, $highValue) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::between($this->hasJoin ? $prefixedColumn : $column, $lowValue, $highValue);
-    }
-
-    public function notBetween($column, $lowValue, $highValue) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::notBetween($this->hasJoin ? $prefixedColumn : $column, $lowValue, $highValue);
-    }
-
-    public function isNull($column) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::isNull($this->hasJoin ? $prefixedColumn : $column);
-    }
-
-    public function notNull($column) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::notNull($this->hasJoin ? $prefixedColumn : $column);
-    }
-
-    public function orderBy($column, $order = self::SORT_ASC) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::orderBy($this->hasJoin ? $prefixedColumn : $column. $order);
-    }
-
-    public function asc($column) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::asc($this->hasJoin ? $prefixedColumn : $column);
-    }
-
-    public function desc($column) {
-        $prefixedColumn = $this->prefixTableNameTo($column, $this->definition->getTable());
-        return parent::desc($this->hasJoin ? $prefixedColumn : $column);
-    }
-
-    public function groupBy() {
-        $columns = func_get_args();
-        $prefixedColumns = $this->prefixTableNameTo($columns, $this->definition->getTable());
-        return parent::groupBy(...($this->hasJoin ? $prefixedColumns : $columns));
-    }
-
-
-    // If mapping has a join, the primary keys and deletion timestamp are automatically prefixed.
-    private function getPrimaryKey() {
-        return $this->hasJoin ? $this->prefixTableNameTo($this->definition->getPrimaryKey(), $this->definition->getTable()) : $this->definition->getPrimaryKey();
-    }
-
-    private function getDeletionTimestamp() {
-        return $this->hasJoin ? $this->prefixTableNameTo($this->definition->getDeletionTimestamp(), $this->definition->getTable()) : $this->definition->getDeletionTimestamp();
+    private function getDeletionTimestamp($prefixed = false) {
+        return ($prefixed) ? $this->prefixTableNameTo($this->definition->getDeletionTimestamp(), $this->definition->getTable()) : $this->definition->getDeletionTimestamp();
     }
 
 /**
@@ -779,11 +581,11 @@ class Mapping extends Table
      */
     private function buildColumns()
     {
-        $columns = $this->getPrimaryKey();
+        $columns = $this->getPrimaryKey(true);
         $required = array_merge($this->definition->getColumns(), $this->columns);
 
         foreach ($this->definition->getProperties() as $item) {
-            $required[] = $item->getLocalColumn();
+            $required[] = ($item->getLocalColumn() === $this->getPrimaryKey()) ? $this->prefixTableNameTo($item->getLocalColumn(), $this->definition->getTable()) : $item->getLocalColumn();
         }
 
         foreach (array_unique($required) as $column) {

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -449,11 +449,11 @@ class Mapping extends Table
     }
 
     private function getPrimaryKey($prefixed = false) {
-        return ($prefixed) ? $this->prefixTableNameTo($this->definition->getPrimaryKey(), $this->definition->getTable()) : $this->definition->getPrimaryKey();
+        return ($prefixed) ? $this->prefixTableNameTo($this->definition->getPrimaryKey()) : $this->definition->getPrimaryKey();
     }
 
     private function getDeletionTimestamp($prefixed = false) {
-        return ($prefixed) ? $this->prefixTableNameTo($this->definition->getDeletionTimestamp(), $this->definition->getTable()) : $this->definition->getDeletionTimestamp();
+        return ($prefixed) ? $this->prefixTableNameTo($this->definition->getDeletionTimestamp()) : $this->definition->getDeletionTimestamp();
     }
 
 /**
@@ -585,7 +585,7 @@ class Mapping extends Table
         $required = array_merge($this->definition->getColumns(), $this->columns);
 
         foreach ($this->definition->getProperties() as $item) {
-            $required[] = ($item->getLocalColumn() === $this->getPrimaryKey()) ? $this->prefixTableNameTo($item->getLocalColumn(), $this->definition->getTable()) : $item->getLocalColumn();
+            $required[] = ($item->getLocalColumn() === $this->getPrimaryKey()) ? $this->prefixTableNameTo($item->getLocalColumn()) : $item->getLocalColumn();
         }
 
         foreach (array_unique($required) as $column) {
@@ -645,7 +645,8 @@ class Mapping extends Table
      *
      * @return string | array
      */
-    function prefixTableNameTo($input, $table) {
+    function prefixTableNameTo($input) {
+        $table = $this->definition->getTable();
         if (is_string($input)) {
             return $this->requiresPrefix($input) ? "$table.$input" : $input;
         } elseif (is_array($input)) {

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -650,7 +650,7 @@ class Mapping extends Table
      *
      * @return string | array
      */
-    function prefixTableNameTo($input) {
+    private function prefixTableNameTo($input) {
         $table = $this->definition->getTable();
         if (is_string($input)) {
             return $this->requiresPrefix($input) ? "$table.$input" : $input;

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -860,27 +860,4 @@ class Mapping extends Table
         }
         return $input;
     }
-
-    /**
-     * Removes table prefix from provided value. Works recursively with arrays.
-     *
-     * @return string | array
-     */
-    function removeTablePrefixFrom($input, $table) {
-        if (is_string($input)) {
-            return $this->requiresPrefix($input) ? $input : substr($input, strlen($table) + 1);
-        } elseif (is_array($input)) {
-            $output = [];
-            foreach ($input as $key => $value) {
-                if (is_string($key)) {
-                    $key = $this->removeTablePrefixFrom($key, $table);
-                } else {
-                    $value = $this->removeTablePrefixFrom($value, $table);
-                }
-                $output[$key] = $value;
-            }
-            return $output;
-        }
-        return $input;
-    }
 }

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -632,10 +632,9 @@ class Mapping extends Table
     }
 
     /**
-     * Appends table name to provided value. Works with strings, arrays, and dictionaries. If multidimensional array is
-     * passed, the values will be updated recursively. If a dictionary is passed, only the
-     * first level of dictionary keys will be modified, does not work recursively with nested dictionaries. It is also
-     * protected from multiple passes and will only prefix the column name once.
+     * Appends table name to provided value. Works with strings and arrays. If multidimensional array is
+     * passed, the values will be updated recursively. Multiple passes are protected and will only prefix
+     * the column name once.
      *
      * String Example:
      *      'field' -> 'table.field'
@@ -643,12 +642,6 @@ class Mapping extends Table
      * Array Example:
      *      ['field', 'field2'] -> ['table.field', 'table.field2']
      *      ['field', ['field2', 'field3']] -> ['table.field', ['table.field2', 'table.field3']]
-     *
-     * Dictionary Example:
-     *      ['field' => 'value'] -> ['table.field' => 'value']
-     *      ['field' => ['field2' => 'value']] -> ['table.field' => ['field2' => 'value']]
-     *      [['field' => 'value']] -> [['table.field' => 'value']]
-     *      [['field' => ['field2' => 'value']]] -> [['table.field' => ['field2' => 'value']]]
      *
      * @return string | array
      */
@@ -660,13 +653,8 @@ class Mapping extends Table
         } elseif (is_array($input)) {
             $output = [];
 
-            foreach ($input as $key => $value) {
-                if (is_string($key)) {
-                    $key = $this->prefixTableNameTo($key);
-                } else {
-                    $value = $this->prefixTableNameTo($value);
-                }
-                $output[$key] = $value;
+            foreach ($input as $value) {
+                $output[] = $this->prefixTableNameTo($value);
             }
 
             return $output;

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -655,9 +655,9 @@ class Mapping extends Table
     private function prefixTableNameTo($input) {
         $table = $this->definition->getTable();
 
-        if (is_string($input)) return $this->requiresPrefix($input) ? "$table.$input" : $input;
-
-        elseif (is_array($input)) {
+        if (is_string($input)) {
+            return $this->requiresPrefix($input) ? "$table.$input" : $input;
+        } elseif (is_array($input)) {
             $output = [];
 
             foreach ($input as $key => $value) {

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -639,9 +639,11 @@ class Mapping extends Table
      *
      * String Example:
      *      'field' -> 'table.field'
+     *
      * Array Example:
      *      ['field', 'field2'] -> ['table.field', 'table.field2']
      *      ['field', ['field2', 'field3']] -> ['table.field', ['table.field2', 'table.field3']]
+     *
      * Dictionary Example:
      *      ['field' => 'value'] -> ['table.field' => 'value']
      *      ['field' => ['field2' => 'value']] -> ['table.field' => ['field2' => 'value']]
@@ -652,10 +654,12 @@ class Mapping extends Table
      */
     private function prefixTableNameTo($input) {
         $table = $this->definition->getTable();
-        if (is_string($input)) {
-            return $this->requiresPrefix($input) ? "$table.$input" : $input;
-        } elseif (is_array($input)) {
+
+        if (is_string($input)) return $this->requiresPrefix($input) ? "$table.$input" : $input;
+
+        elseif (is_array($input)) {
             $output = [];
+
             foreach ($input as $key => $value) {
                 if (is_string($key)) {
                     $key = $this->prefixTableNameTo($key);
@@ -664,8 +668,10 @@ class Mapping extends Table
                 }
                 $output[$key] = $value;
             }
+
             return $output;
         }
+
         return $input;
     }
 }

--- a/tests/Fixtures.sql
+++ b/tests/Fixtures.sql
@@ -1,6 +1,6 @@
 -- Prepare schema
 DROP TABLE IF EXISTS customers;
-CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT, date_deleted TEXT);
 
 DROP TABLE IF EXISTS orders;
 CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER, date_created TEXT, date_deleted TEXT);

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -313,18 +313,6 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $actualOutput = $method->invoke($this->getMapping(), $input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
-        // Test with dictionary input
-        $input = ['field1' => 'value1', 'field2' => 'value2'];
-        $expectedOutput = ['customers.field1' => 'value1', 'customers.field2' => 'value2'];
-        $actualOutput = $method->invoke($this->getMapping(), $input);
-        $this->assertEquals($expectedOutput, $actualOutput);
-
-        // Test with dictionary with nested dictionary input
-        $input = ['field1' => 'value1', 'field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
-        $expectedOutput = ['customers.field1' => 'value1', 'customers.field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
-        $actualOutput = $method->invoke($this->getMapping(), $input);
-        $this->assertEquals($expectedOutput, $actualOutput);
-
         // Test multi-pass safety
         $input = ['field1', 'field2'];
         $expectedOutput = ['customers.field1', 'customers.field2'];

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -294,44 +294,44 @@ class MappingTest extends \PHPUnit\Framework\TestCase
     {
         // Test with string input
         $input = 'field';
-        $expectedOutput = 'table.field';
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input, 'table');
+        $expectedOutput = 'customers.field';
+        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with array input
         $input = ['field1', 'field2'];
-        $expectedOutput = ['table.field1', 'table.field2'];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input, 'table');
+        $expectedOutput = ['customers.field1', 'customers.field2'];
+        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with nested array input
         $input = ['field1', ['nestedField1', 'nestedField2']];
-        $expectedOutput = ['table.field1', ['table.nestedField1', 'table.nestedField2']];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input, 'table');
+        $expectedOutput = ['customers.field1', ['customers.nestedField1', 'customers.nestedField2']];
+        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with dictionary input
         $input = ['field1' => 'value1', 'field2' => 'value2'];
-        $expectedOutput = ['table.field1' => 'value1', 'table.field2' => 'value2'];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input, 'table');
+        $expectedOutput = ['customers.field1' => 'value1', 'customers.field2' => 'value2'];
+        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with dictionary with nested dictionary input
         $input = ['field1' => 'value1', 'field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
-        $expectedOutput = ['table.field1' => 'value1', 'table.field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input, 'table');
+        $expectedOutput = ['customers.field1' => 'value1', 'customers.field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
+        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test multi-pass safety
         $input = ['field1', 'field2'];
-        $expectedOutput = ['table.field1', 'table.field2'];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($this->getMapping()->prefixTableNameTo($input, 'table'), 'table');
+        $expectedOutput = ['customers.field1', 'customers.field2'];
+        $actualOutput = $this->getMapping()->prefixTableNameTo($this->getMapping()->prefixTableNameTo($input));
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Don't change input if other table already appended
         $input = 'table2.field';
         $expectedOutput = 'table2.field';
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input, 'table');
+        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
         $this->assertEquals($expectedOutput, $actualOutput);
     }
 

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -322,40 +322,10 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $actualOutput = $this->getMapping()->prefixTableNameTo($input, 'table');
         $this->assertEquals($expectedOutput, $actualOutput);
 
-        $input = 'table.field';
-        $expectedOutput = 'field';
-        $actualOutput = $this->getMapping()->removeTablePrefixFrom($input, 'table');
-        $this->assertEquals($expectedOutput, $actualOutput);
-
-        $input = ['table.field1', 'table.field2'];
-        $expectedOutput = ['field1', 'field2'];
-        $actualOutput = $this->getMapping()->removeTablePrefixFrom($input, 'table');
-        $this->assertEquals($expectedOutput, $actualOutput);
-
-        $input = ['table.field1', ['table.nestedField1', 'table.nestedField2']];
-        $expectedOutput = ['field1', ['nestedField1', 'nestedField2']];
-        $actualOutput = $this->getMapping()->removeTablePrefixFrom($input, 'table');
-        $this->assertEquals($expectedOutput, $actualOutput);
-
-        $input = ['table.field1' => 'value1', 'table.field2' => 'value2'];
-        $expectedOutput = ['field1' => 'value1', 'field2' => 'value2'];
-        $actualOutput = $this->getMapping()->removeTablePrefixFrom($input, 'table');
-        $this->assertEquals($expectedOutput, $actualOutput);
-
-        $input = ['table.field1' => 'value1', 'table.field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
-        $expectedOutput = ['field1' => 'value1', 'field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
-        $actualOutput = $this->getMapping()->removeTablePrefixFrom($input, 'table');
-        $this->assertEquals($expectedOutput, $actualOutput);
-
         // Test multi-pass safety
         $input = ['field1', 'field2'];
         $expectedOutput = ['table.field1', 'table.field2'];
         $actualOutput = $this->getMapping()->prefixTableNameTo($this->getMapping()->prefixTableNameTo($input, 'table'), 'table');
-        $this->assertEquals($expectedOutput, $actualOutput);
-
-        $input = ['table.field1', 'table.field2'];
-        $expectedOutput = ['field1', 'field2'];
-        $actualOutput = $this->getMapping()->removeTablePrefixFrom($this->getMapping()->removeTablePrefixFrom($input, 'table'), 'table');
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Don't change input if other table already appended

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -339,7 +339,7 @@ class MappingTest extends \PHPUnit\Framework\TestCase
     {
         $customer = $this->getMapping()
             ->join('orders', 'customer_id', 'id')
-            ->eq('id', 2)
+            ->eq('customers.id', 2)
             ->findOne();
 
         $this->assertEquals('Jane Doe', $customer['name']);
@@ -357,7 +357,7 @@ class MappingTest extends \PHPUnit\Framework\TestCase
     {
         $customer = $this->getMapping()
             ->left('orders', 'o', 'customer_id', 'customers', 'id')
-            ->eq('id', 2)
+            ->eq('customers.id', 2)
             ->findOne();
 
         $this->assertEquals('Jane Doe', $customer['name']);
@@ -376,7 +376,7 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $customer = $this->getMapping()
             ->left('orders', 'o', 'customer_id', 'customers', 'id')
             ->left('items', 'i', 'order_id', 'o', 'id')
-            ->eq('id', 2)
+            ->eq('customers.id', 2)
             ->findOne();
 
         $this->assertEquals('Jane Doe', $customer['name']);

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -292,46 +292,49 @@ class MappingTest extends \PHPUnit\Framework\TestCase
 
     public function testPrefixAndRemoveTableName()
     {
+        $method = new \ReflectionMethod('PicoMapper\Mapping', 'prefixTableNameTo');
+        $method->setAccessible(true);
+
         // Test with string input
         $input = 'field';
         $expectedOutput = 'customers.field';
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
+        $actualOutput = $method->invoke($this->getMapping(), $input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with array input
         $input = ['field1', 'field2'];
         $expectedOutput = ['customers.field1', 'customers.field2'];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
+        $actualOutput = $method->invoke($this->getMapping(), $input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with nested array input
         $input = ['field1', ['nestedField1', 'nestedField2']];
         $expectedOutput = ['customers.field1', ['customers.nestedField1', 'customers.nestedField2']];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
+        $actualOutput = $method->invoke($this->getMapping(), $input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with dictionary input
         $input = ['field1' => 'value1', 'field2' => 'value2'];
         $expectedOutput = ['customers.field1' => 'value1', 'customers.field2' => 'value2'];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
+        $actualOutput = $method->invoke($this->getMapping(), $input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test with dictionary with nested dictionary input
         $input = ['field1' => 'value1', 'field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
         $expectedOutput = ['customers.field1' => 'value1', 'customers.field2' => ['nestedField1' => 'nestedValue1', 'nestedField2' => 'nestedValue2']];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
+        $actualOutput = $method->invoke($this->getMapping(), $input);
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Test multi-pass safety
         $input = ['field1', 'field2'];
         $expectedOutput = ['customers.field1', 'customers.field2'];
-        $actualOutput = $this->getMapping()->prefixTableNameTo($this->getMapping()->prefixTableNameTo($input));
+        $actualOutput = $method->invoke($this->getMapping(), $method->invoke($this->getMapping(), $input));
         $this->assertEquals($expectedOutput, $actualOutput);
 
         // Don't change input if other table already appended
         $input = 'table2.field';
         $expectedOutput = 'table2.field';
-        $actualOutput = $this->getMapping()->prefixTableNameTo($input);
+        $actualOutput = $method->invoke($this->getMapping(), $input);
         $this->assertEquals($expectedOutput, $actualOutput);
     }
 


### PR DESCRIPTION
This PR adds support to use JOIN methods directly on Mapping just as you would on a typical table in PicoDB.

Previously, if you wanted to use JOIN on a mapping you would need a separate mapping specifically prefixing the root table to the primary keys and the deletion timestamp. Now PicoMapper will automatically prefix them, if not already. In my testing, I have determined this does not introduce any breaking changes.

Just as with PicoDB, if a column is considered ambiguous, you will have to manually prefix it in your usage. If a field is not ambiguous you can use the root column name with no prefix.

There is a PR in tithely/hub checking breaking changes: https://github.com/tithely/hub/pull/967
And a second PR in tithely/hub showing the difference in using this update to enhance organization searching: https://github.com/tithely/hub/pull/978