### PR TITLE
Always throw exceptions rather than sometimes returning false

### DIFF
--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -171,7 +171,7 @@ class Mapping extends Table
      *
      * @param array $data
      * @return boolean
-     * @throws \Exception
+     * @throws MappingException
      */
     public function update(array $data = array())
     {
@@ -183,7 +183,7 @@ class Mapping extends Table
 
         foreach ($primaryKey as $column) {
             if (!array_key_exists($column, $data)) {
-                throw new \Exception('Failed to update record. Missing primary key column: ' . $column);
+                throw new MappingException('Failed to update record. Missing primary key column: ' . $column);
             }
 
             if (is_null($data[$column])) {
@@ -194,7 +194,7 @@ class Mapping extends Table
         }
 
         if (!$original = $this->findOne()) {
-            throw new \Exception('Failed to update record. Original not found.');
+            throw new MappingException('Failed to update record. Original not found.');
         }
 
         $useTransaction = !$this->db->getConnection()->inTransaction();
@@ -231,7 +231,7 @@ class Mapping extends Table
      *
      * @param array $data
      * @return bool
-     * @throws \Exception
+     * @throws MappingException
      */
     public function save(array $data)
     {
@@ -239,7 +239,7 @@ class Mapping extends Table
 
         foreach ($primaryKey as $column) {
             if (!array_key_exists($column, $data)) {
-                throw new \Exception('Failed to save record. Missing primary key column: ' . $column);
+                throw new MappingException('Failed to save record. Missing primary key column: ' . $column);
             }
 
             if (is_null($data[$column])) {
@@ -257,7 +257,7 @@ class Mapping extends Table
      * Removes data matching the condition.
      *
      * @return bool
-     * @throws \Exception
+     * @throws MappingException
      */
     public function remove()
     {
@@ -303,7 +303,7 @@ class Mapping extends Table
      * @param array $original
      * @param array $deleteIds
      * @return array
-     * @throws \Exception
+     * @throws MappingException
      */
     private function replace(array $data, array $original, array $deleteIds = [])
     {
@@ -405,7 +405,7 @@ class Mapping extends Table
      * mapping tables to primary key values.
      *
      * @param array $ids
-     * @throws \Exception
+     * @throws MappingException
      */
     private function delete($ids = [])
     {
@@ -468,7 +468,7 @@ class Mapping extends Table
                     }
 
                     if (!$result) {
-                        throw new \Exception('Failed to delete records.');
+                        throw new MappingException('Failed to delete records.');
                     }
                 }
             }

--- a/src/MappingException.php
+++ b/src/MappingException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PicoMapper;
+
+class MappingException extends \Exception
+{
+}

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -192,7 +192,7 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function  testReadOnlyInsert()
+    public function testReadOnlyInsert()
     {
         $customer = [
             'id' => 10,
@@ -288,8 +288,59 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         } catch (SQLException $exception) {
         }
 
+        $this->assertFalse($this->db->getConnection()->inTransaction());
+
         $inserted = $this->getMapping()->eq('id', 3)->findOne();
         $this->assertNull($inserted);
+    }
+
+    public function testInsertDuplicateThrowsException()
+    {
+        $this->expectException(SQLException::class);
+        $this->expectExceptionMessage('UNIQUE constraint failed');
+
+        $customer = [
+            'id' => 1,
+            'name' => 'Dave Matthews',
+            'orders' => []
+        ];
+
+        $this->getMapping()->insert($customer);
+    }
+
+    public function testInsertDuplicateChildrenThrowsException()
+    {
+        $this->expectException(SQLException::class);
+        $this->expectExceptionMessage('UNIQUE constraint failed');
+
+        $customer = [
+            'id' => 3,
+            'name' => 'Dave Matthews',
+            'orders' => [
+                [
+                    'id' => 4,
+                    'date_created' => '2018-02-01',
+                    'discount' => [
+                        'description' => 'Dessert Discount',
+                        'amount' => 20
+                    ],
+                    'items' => [
+                        [
+                            'id' => 7,
+                            'description' => 'Ice Cream',
+                            'amount' => 400
+                        ],
+                        [
+                            'id' => 7,
+                            'description' => 'Cookies',
+                            'amount' => '230'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->getMapping()->insert($customer);
     }
 
     public function testUpdateRollback()
@@ -297,11 +348,88 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $customer = $this->getMapping()->eq('id', 1)->findOne();
         $original = $customer;
 
-        $customer['orders'][0]['items'][] = ['id' => '3'];
-        $this->getMapping()->update($customer);
+        $customer['orders'][0]['items'] = array_merge(
+            $customer['orders'][0]['items'],
+            [
+                [
+                    'id' => 7,
+                    'description' => 'Ice Cream',
+                    'amount' => 400
+                ],
+                [
+                    'id' => 7,
+                    'description' => 'Cookies',
+                    'amount' => '230'
+                ]
+            ]
+        );
+
+        try {
+            $this->getMapping()->update($customer);
+        } catch (SQLException $exception) {
+        }
 
         $updated = $this->getMapping()->eq('id', 1)->findOne();
         $this->assertEquals($original, $updated);
+    }
+
+    public function testUpdateThrowsExceptionWhenInsertingDuplicateChildrenRecords()
+    {
+        $this->expectException(SQLException::class);
+        $this->expectExceptionMessage('UNIQUE constraint failed');
+
+        $customer = $this->getMapping()->eq('id', 1)->findOne();
+
+        $customer['orders'][0]['items'] = array_merge(
+            $customer['orders'][0]['items'],
+            [
+                [
+                    'id' => 7,
+                    'description' => 'Ice Cream',
+                    'amount' => 400
+                ],
+                [
+                    'id' => 7,
+                    'description' => 'Cookies',
+                    'amount' => '230'
+                ]
+            ]
+        );
+
+        $this->getMapping()->update($customer);
+    }
+
+    public function testUpdateDoesNotErrorWhenUpdatingDuplicateChildrenRecords()
+    {
+        $customer = $this->getMapping()->eq('id', 1)->findOne();
+        $original = $customer;
+
+        // You can provide the same item multiple times to update.
+        $customer['orders'][0]['items'] = array_merge(
+            $customer['orders'][0]['items'],
+            [
+                [
+                    'id' => 3,
+                    'description' => 'Ice Cream',
+                    'amount' => 400
+                ],
+                [
+                    'id' => 3,
+                    'description' => 'Chocolate Bar',
+                    'amount' => 600
+                ]
+            ]
+        );
+
+        $this->getMapping()->update($customer);
+
+        $updated = $this->getMapping()->eq('id', 1)->findOne();
+        $this->assertNotEquals($original, $updated);
+
+        // The last array entry for that item will be the one reflected in the database.
+        $this->assertEquals($updated['orders'][0]['items'][2]['id'], 3);
+        $this->assertEquals($updated['orders'][0]['items'][2]['description'],  'Chocolate Bar');
+        $this->assertEquals($updated['orders'][0]['items'][2]['amount'], 600);
     }
 
     public function testPrefixAndRemoveTableName()

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -432,6 +432,43 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($updated['orders'][0]['items'][2]['amount'], 600);
     }
 
+    public function testUpdateThrowsMappingExceptionWhenMissingPrimaryKey()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Failed to update record. Missing primary key column: id');
+
+        $customer = [
+            'name' => 'John Doe',
+        ];
+
+        $this->getMapping()->update($customer);
+    }
+
+    public function testUpdateThrowsMappingExceptionWhenOriginalNotFound()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Failed to update record. Original not found.');
+
+        $customer = [
+            'id' => 999,
+            'name' => 'Nonexistent Customer',
+        ];
+
+        $this->getMapping()->update($customer);
+    }
+
+    public function testSaveThrowsMappingExceptionWhenMissingPrimaryKey()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Failed to save record. Missing primary key column: id');
+
+        $customer = [
+            'name' => 'John Doe',
+        ];
+
+        $this->getMapping()->save($customer);
+    }
+
     public function testPrefixAndRemoveTableName()
     {
         $method = new \ReflectionMethod('PicoMapper\Mapping', 'prefixTableNameTo');


### PR DESCRIPTION
This will require a closer look, but I've been using these changes for a while with success.

Reasoning:
In most situations a problem with a query resulted in picodb's SQLException propagating out making for easy handling.
Here's the source of the exception in picodb for reference:
```php
   // StatementHandler.php   

    public function execute()
    {
        try {
            $this->beforeExecute();

            $pdoStatement = $this->db->getConnection()->prepare($this->sql);
            $this->bindParams($pdoStatement);
            $pdoStatement->execute();

            $this->afterExecute();
            return $pdoStatement;
        } catch (PDOException $e) {
            return $this->handleSqlError($e);
        }
    }

    public function handleSqlError(PDOException $e)
    {
        $this->cleanup();
        $this->db->cancelTransaction();
        $this->db->setLogMessage($e->getMessage());

        throw new SQLException('SQL Error: '.$e->getMessage());
    }
```

However in some situations, this exception is caught in picomapper and instead false is returned. This makes handling errors more difficult. The most common situation I encountered this, was when I had a bug and was attempting to update an aggregate with new duplicate child records. It would attempt to insert a duplicate child and that resulting exception would be caught and false would be returned. I was confused why my request was succeeding but my record wasn't updating. After diving in I figured out why, and thus this PR :sweat_smile: 
before:
```php
    } catch (\Exception $e) {
        if ($useTransaction) {
            $this->db->cancelTransaction();
        }

        return false;
    }
```
after:
```php
    } catch (\Exception $exception) {
        if ($useTransaction) {
            $this->db->cancelTransaction();
        }

        throw $exception;
    }
```

----
I've also opted to simply remove the returning false. Such as this example:
```php
    if (!parent::insert($base)) {
            // Transaction already cancelled by the statement handler
            return false;
    }
```
In the above example false is never returned, as the SQLException from picodb is thrown already. So I've simply replaced it with:
```php
parent::insert($base);
```

----
I've also escalated to exception any errors in the picomapper library that previously returned false, for example:
before:
```php
    if (!$original = $this->findOne()) {
        return false;
    }
```
after:
```php
    if (!$original = $this->findOne()) {
        throw new \Exception('Failed to update record. Original not found.');
    }
```
Maybe these should use a specific exception class from picomapper, I'm happy to add that if you have thoughts. I'd just kept it simple for now.

