### PR TITLE
Override exists to use deletionTimestamp and use it when saving to prevent mapping the entire object twice.

### DIFF
--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -83,6 +83,20 @@ class Mapping extends Table
     }
 
     /**
+     * Checks if any records exist matching the current conditions.
+     *
+     * @return bool
+     */
+    public function exists()
+    {
+        if ($this->definition->getDeletionTimestamp()) {
+            $this->isNull($this->prefixTableNameTo($this->definition->getDeletionTimestamp()));
+        }
+
+        return parent::exists();
+    }
+
+    /**
      * Counts all records.
      *
      * @return int
@@ -249,8 +263,7 @@ class Mapping extends Table
             }
         }
 
-        $original = $this->findOne();
-        return $original ? $this->update($data) : $this->insert($data);
+        return $this->exists() ? $this->update($data) : $this->insert($data);
     }
 
     /**

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -192,6 +192,19 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testExists()
+    {
+        $this->assertTrue($this->getMapping()->eq('id', 1)->exists());
+        $this->assertFalse($this->getMapping()->eq('id', 999)->exists());
+    }
+
+    public function testExistsReturnsFalseForSoftDeletedRecord()
+    {
+        $this->getMapping()->eq('id', 1)->remove();
+
+        $this->assertFalse($this->getMapping()->eq('id', 1)->exists());
+    }
+
     public function testReadOnlyInsert()
     {
         $customer = [

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -321,6 +321,22 @@ class MappingTest extends \PHPUnit\Framework\TestCase
         $this->getMapping()->insert($customer);
     }
 
+    public function testInsertDuplicateOfSoftDeletedRecordThrowsException()
+    {
+        $this->expectException(SQLException::class);
+        $this->expectExceptionMessage('UNIQUE constraint failed');
+
+        $this->getMapping()->eq('id', 1)->remove();
+
+        $customer = [
+            'id' => 1,
+            'name' => 'Dave Matthews',
+            'orders' => []
+        ];
+
+        $this->getMapping()->insert($customer);
+    }
+
     public function testInsertDuplicateChildrenThrowsException()
     {
         $this->expectException(SQLException::class);


### PR DESCRIPTION
Override exists to use the deletion timestamp if it exists.
Update save() to use exists rather than actually retrieving the object. This saves mapping the entire object and all relationships twice.